### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # MHFlexibleHeader
 Flexible Section Header for Tableview
 
-[![Cocoapods](http://img.shields.io/cocoapods/v/MHFlexibleHeader.svg?style=flat)](http://www.cocoapods.org/?q= mhflexibleheader)
-[![Cocoapods](http://img.shields.io/cocoapods/l/MHFlexibleHeader.svg?style=flat)](http://www.cocoapods.org/?q=mhflexibleheader)
-[![Cocoapods](http://img.shields.io/cocoapods/p/MHFlexibleHeader.svg?style=flat)](http://www.cocoapods.org/?q= mhflexibleheader)
+[![CocoaPods](http://img.shields.io/cocoapods/v/MHFlexibleHeader.svg?style=flat)](http://www.cocoapods.org/?q= mhflexibleheader)
+[![CocoaPods](http://img.shields.io/cocoapods/l/MHFlexibleHeader.svg?style=flat)](http://www.cocoapods.org/?q=mhflexibleheader)
+[![CocoaPods](http://img.shields.io/cocoapods/p/MHFlexibleHeader.svg?style=flat)](http://www.cocoapods.org/?q= mhflexibleheader)
 [![Join the chat at https://gitter.im/MickeyHub/MHFlexibleHeader](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/MickeyHub/MHFlexibleHeader)
 [![Contact](https://img.shields.io/badge/contact-Mickey-green.svg)](http://weibo.com/u/2194071594)
 
@@ -13,7 +13,7 @@ A subclass of UITableView to fix header when scroll up and movable header when s
 
 ![MHScrollingHeader](https://github.com/MickeyHub/MHFlexibleHeader/raw/master/screenshot.gif)
 
-#Setup with Cocoapods
+#Setup with CocoaPods
 
 ```
 pod 'MHFlexibleHeader', '~> 0.0.1'


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
